### PR TITLE
RelationshipType: fix crash on prev null data

### DIFF
--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -228,8 +228,8 @@ relationship.prototype.updateItem = function (item, data, callback) {
 
 	// Are we handling a many relationship or just one value?
 	if (this.many) {
-		var arr = item.get(this.path);
-		var _old = arr.map(function (i) { return String(i); });
+		var arr = item.get(this.path) || [];
+		var _old = arr.map(String);
 		var _new = value;
 		if (!utils.isArray(_new)) {
 			_new = String(_new || '').split(',');


### PR DESCRIPTION
This can happen when you add a multi relationship to an existing model

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

